### PR TITLE
fixed delete function in Collection wrong param name. Fixed current_g…

### DIFF
--- a/pfunk/collection.py
+++ b/pfunk/collection.py
@@ -95,7 +95,7 @@ class Collection(BaseSchema, metaclass=PFunkDeclarativeVariablesMetaclass):
     @classmethod
     def create(cls, _credentials=None, _token=None, **kwargs):
         c = cls(**kwargs)
-        c.save(_credentials=_credentials)
+        c.save(_credentials=_credentials, _token=_token)
         return c
 
     @classmethod
@@ -287,4 +287,4 @@ class Collection(BaseSchema, metaclass=PFunkDeclarativeVariablesMetaclass):
         ).get('data')]
 
     def delete(self, _token=None):
-        self.client(token=_token).query(q.delete(self.ref))
+        self.client(_token=_token).query(q.delete(self.ref))

--- a/pfunk/contrib/auth/resources.py
+++ b/pfunk/contrib/auth/resources.py
@@ -268,7 +268,7 @@ class GenericUserBasedRole(GenericAuthorizationRole):
 class GenericGroupBasedRole(GenericAuthorizationRole):
     relation_index_name = 'users_groups_by_group_and_user'
     through_user_field = 'userID'
-    current_group_field = 'groupID'
+    current_group_field = 'group'
     user_table = 'User'
     name_suffix = 'group_based_crud_role'
 

--- a/pfunk/contrib/auth/resources.py
+++ b/pfunk/contrib/auth/resources.py
@@ -268,7 +268,7 @@ class GenericUserBasedRole(GenericAuthorizationRole):
 class GenericGroupBasedRole(GenericAuthorizationRole):
     relation_index_name = 'users_groups_by_group_and_user'
     through_user_field = 'userID'
-    current_group_field = 'group'
+    current_group_field = 'groupID'
     user_table = 'User'
     name_suffix = 'group_based_crud_role'
 

--- a/pfunk/db.py
+++ b/pfunk/db.py
@@ -44,7 +44,8 @@ class Database(Schema):
         elif issubclass(resource, Index):
             resource_list = self._index_list
         else:
-            raise ValueError('Resource has to be one of the following: Collection, Enum, or Index')
+            raise ValueError(
+                'Resource has to be one of the following: Collection, Enum, or Index')
         if not resource in resource_list:
             resource_list.append(resource)
 


### PR DESCRIPTION
- Fixed `delete` function not working because of wrong param key.
- Fixed `current_group_name` in GenericGroupBasedRole to mirror the key in many-to-many collection