### PR TITLE
Refactored Stripe views, collections and unit tests

### DIFF
--- a/pfunk/contrib/ecommerce/collections.py
+++ b/pfunk/contrib/ecommerce/collections.py
@@ -22,7 +22,10 @@ class StripePackage(Collection):
         fields and functions to match your system.
 
         Read and detail views are naturally public. Write operations
-        requires authentication from admin group.
+        requires authentication from admin group. While it grealty
+        depends on your app, it is recommended to have this only 
+        modified by the admins and use `StripeCustomer` model to
+        attach a `stripe_id` to a model that is bound for payment.
     """
     use_crud_views = False
     collection_roles = [GenericGroupBasedRole]
@@ -47,11 +50,13 @@ class StripeCustomer(Collection):
         This is only a base model made to give an idea how 
         can you structure your collections. Override the 
         fields and functions to match your system.
+
+        Should be used as the
     """
-    collection_roles = [GenericUserBasedRole]
     user = ReferenceField(User)
-    customer_id = StringField(required=True)
-    package = ReferenceField(StripePackage)
+    collection_roles = [GenericUserBasedRole]
+    stripe_id = StringField(required=True, unique=True)
+    description = StringField()
 
     def __unicode__(self):
         return self.customer_id

--- a/pfunk/contrib/ecommerce/collections.py
+++ b/pfunk/contrib/ecommerce/collections.py
@@ -7,7 +7,7 @@ from pfunk.exceptions import DocNotFound
 from pfunk.fields import EmailField, SlugField, ManyToManyField, ListField, ReferenceField, StringField, EnumField, FloatField
 from pfunk.contrib.auth.resources import GenericGroupBasedRole, GenericUserBasedRole, Public, UserRole
 from pfunk.contrib.ecommerce.resources import StripePublic
-from pfunk.contrib.ecommerce.views import ListStripePackage, DetailStripePackage
+from pfunk.contrib.ecommerce.views import BaseWebhookView, ListStripePackage, DetailStripePackage, CheckoutSuccessView
 from pfunk.web.views.json import CreateView, UpdateView, DeleteView
 
 
@@ -29,7 +29,8 @@ class StripePackage(Collection):
     """
     use_crud_views = False
     collection_roles = [GenericGroupBasedRole]
-    collection_views = [ListStripePackage, DetailStripePackage, CreateView, UpdateView, DeleteView]
+    collection_views = [ListStripePackage, DetailStripePackage,
+                        CheckoutSuccessView, CreateView, UpdateView, DeleteView]
     stripe_id = StringField(required=True)
     name = StringField(required=True)
     price = FloatField(required=True)
@@ -50,13 +51,12 @@ class StripeCustomer(Collection):
         This is only a base model made to give an idea how 
         can you structure your collections. Override the 
         fields and functions to match your system.
-
-        Should be used as the
     """
     user = ReferenceField(User)
     collection_roles = [GenericUserBasedRole]
     stripe_id = StringField(required=True, unique=True)
     description = StringField()
+    collection_views = [BaseWebhookView]
 
     def __unicode__(self):
         return self.customer_id

--- a/pfunk/contrib/ecommerce/collections.py
+++ b/pfunk/contrib/ecommerce/collections.py
@@ -55,7 +55,6 @@ class StripeCustomer(Collection):
     user = ReferenceField(User)
     collection_roles = [GenericUserBasedRole]
     stripe_id = StringField(required=True, unique=True)
-    description = StringField()
     collection_views = [BaseWebhookView]
 
     def __unicode__(self):

--- a/pfunk/contrib/ecommerce/views.py
+++ b/pfunk/contrib/ecommerce/views.py
@@ -15,6 +15,7 @@ from pfunk.contrib.email.ses import SESBackend
 from pfunk.contrib.auth.collections import Group, User
 from pfunk.web.views.base import ActionMixin
 
+
 stripe.api_key = env('STRIPE_API_KEY')
 STRIPE_PUBLISHABLE_KEY = env('STRIPE_PUBLISHABLE_KEY')
 STRIPE_WEBHOOK_SECRET = env('STRIPE_WEBHOOK_SECRET')
@@ -110,7 +111,7 @@ class BaseWebhookView(JSONView, ActionMixin):
         if isinstance(action, collections.Callable):
             action()
             return {'success': 'ok'}
-        raise super().not_found_class()
+        raise NotImplementedError
 
     def post(self, request, *args, **kwargs):
         self.request = request
@@ -137,7 +138,7 @@ class BaseWebhookView(JSONView, ActionMixin):
         except (KeyError, JSONDecodeError):
             return True
         try:
-            return self.request.META['REMOTE_ADDR'] in valid_ips
+            return self.request.source_ip in valid_ips
         except KeyError:
             return False
 

--- a/pfunk/contrib/ecommerce/views.py
+++ b/pfunk/contrib/ecommerce/views.py
@@ -6,6 +6,7 @@ import bleach
 from envs import env
 from datetime import datetime
 from json import JSONDecodeError
+from werkzeug.routing import Rule
 from jinja2 import Environment, BaseLoader
 
 from pfunk.contrib.email import ses
@@ -72,29 +73,50 @@ class CheckoutView(DetailView):
         return context
 
 
-class CheckoutSuccessView(DetailView):
+class CheckoutSuccessView(DetailView, ActionMixin):
     """ Defines action from the result of `CheckoutView` """
+    action = 'checkout-success'
+    http_method_names = ['get']
 
-    def get_object(self, queryset=None):
+    @classmethod
+    def url(cls, collection):
+        return Rule(f'/{collection.get_class_name()}/{cls.action}/<string:id>/', endpoint=cls.as_view(collection),
+                    methods=cls.http_methods)
+
+    def get_query(self, *args, **kwargs):
         """ Acquires the object from the `SessionView` """
-        try:
-            session_id = self.request.GET['session_id']
-        except KeyError:
-            raise DocNotFound
+        session_id = self.request.kwargs.get('id')
         self.stripe_session = stripe.checkout.Session.retrieve(session_id)
-        return self.model.objects.get(stripe_id=self.stripe_session.client_reference_id)
+        # NOTE: Chose listing instead of indexing under the assumption of limited  paid packages. Override if needed
+        pkg = [pkg for pkg in self.collection.all() if pkg.stripe_id ==
+               self.stripe_session.client_reference_id]
+        if pkg:
+            return pkg
+        raise DocNotFound
 
-    def get_context_data(self, **kwargs):
-        context = super().get_context_data(**kwargs)
-        context['stripe_session'] = self.stripe_session
-        return context
 
-
-class BaseWebhookView(JSONView, ActionMixin):
+class BaseWebhookView(CreateView, ActionMixin):
     """ Base class to use for executing Stripe webhook actions """
+    login_required = False
     action = 'webhook'
     http_method_names = ['post']
     webhook_signing_secret = STRIPE_WEBHOOK_SECRET
+
+    def get_query(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.event = self.check_signing_secret()
+        try:
+            self.event_json = json.loads(self.request.body)
+        except TypeError:
+            self.event_json = self.request.body
+
+        try:
+            self.object = self.event.data.object
+        except AttributeError:
+            self.object = None
+
+        return self.event_action()
 
     def event_action(self):
         """ Transforms Stripe action to snake case for easier 
@@ -107,25 +129,12 @@ class BaseWebhookView(JSONView, ActionMixin):
             that
         """
         event_type = self.event.type.replace('.', '_')
-        action = getattr(self, event_type, None)
-        if isinstance(action, collections.Callable):
-            action()
-            return {'success': 'ok'}
+        if event_type is str:
+            action = getattr(self, event_type, None)
+            if isinstance(action, collections.Callable):
+                action()
+                return {'success': 'ok'}
         raise NotImplementedError
-
-    def post(self, request, *args, **kwargs):
-        self.request = request
-        self.args = args
-        self.kwargs = kwargs
-        self.event = self.check_signing_secret()
-        self.event_json = json.loads(self.request.body)
-
-        try:
-            self.object = self.event.data.object
-        except AttributeError:
-            self.object = None
-
-        return self.event_action()
 
     def check_ip(self):
         """
@@ -151,8 +160,7 @@ class BaseWebhookView(JSONView, ActionMixin):
                 DEFAULT_FROM_EMAIL (str): default `from` email
         """
         if not context:
-            context = {'object': self.object,
-                       'request_body': self.request.body}
+            context = {'request_body': self.request.body}
         if template_name:
             rtemplate = Environment(
                 loader=BaseLoader()).from_string(template_name)
@@ -173,13 +181,15 @@ class BaseWebhookView(JSONView, ActionMixin):
 
     def check_signing_secret(self):
         """
-        Make sure the request's Stripe signature to make sure it matches our signing secret.
-        :return: HttpResponse or Stripe Event Object
+        Make sure the request's Stripe signature to make sure it matches our signing secret 
+        then returns the event 
+        
+        :return: Stripe Event Object
         """
         # If we are running tests we can't verify the signature but we need the event objects
 
         event = stripe.Webhook.construct_event(
-            self.request.body, self.request.META['HTTP_STRIPE_SIGNATURE'], self.webhook_signing_secret
+            self.request.body, self.request.headers['HTTP_STRIPE_SIGNATURE'], self.webhook_signing_secret
         )
         return event
 
@@ -188,8 +198,9 @@ class BaseWebhookView(JSONView, ActionMixin):
 
     def checkout_session_completed(self):
         """ A method to override to implement custom actions 
-            after successful Stripe checkout
+            after successful Stripe checkout. 
 
+            This is a Stripe event.
             Use this method by subclassing this class in your
             custom claas
         """

--- a/pfunk/tests/test_web_stripe.py
+++ b/pfunk/tests/test_web_stripe.py
@@ -16,14 +16,15 @@ class TestWebStripe(APITestCase):
         self.user = User.create(username='test', email='tlasso@example.org', first_name='Ted',
                                 last_name='Lasso', _credentials='abc123', account_status='ACTIVE',
                                 groups=[self.group])
-        self.stripe_pkg = StripePackage.create(
-            stripe_id='100', price='10', description='unit testing...', name='unit test package')
+        self.stripe_pkg = StripePackage.create(group=self.group,
+                                               stripe_id='100', price='10', description='unit testing...', name='unit test package')
         # self.stripe_customer = StripeCustomer.create(user=self.user, customer_id='100', package=self.stripe_pkg)
 
         self.token, self.exp = User.api_login("test", "abc123")
         self.app = self.project.wsgi_app
         self.c = Client(self.app)
-        # self.user.add_permissions(self.group, [PermissionGroup(StripePackage, ['create', 'read', 'write', 'delete'])])
+        self.user.add_permissions(self.group, [PermissionGroup(
+            StripePackage, ['create', 'read', 'write', 'delete'])])
 
     def test_list_package(self):
         res = self.c.get('/stripepackage/list/', headers={
@@ -43,44 +44,55 @@ class TestWebStripe(APITestCase):
             res.json['data']['data']['name'],
             self.stripe_pkg.name)
 
-    # TODO: Fix `forbidden` error in stripe views
     def test_create_package(self):
+        self.assertNotIn("new stripe pkg", [
+            pkg.name for pkg in StripePackage.all()])
         res = self.c.post('/stripepackage/create/',
                           json={
                               'stripe_id': '123',
-                              'name': 'stripe_pkg',
+                              'name': 'new stripe pkg',
                               'price': 10.10,
-                              'description': 'a test package'
+                              'description': 'a test package',
+                              'group': self.group.ref.id()
                           },
                           headers={
-                              "Authorization": self.token,
-                              "Content-Type": "application/json"
+                              "Authorization": self.token
                           })
 
-        print(res.json)
+        self.assertTrue(res.json['success'])
+        self.assertIn("new stripe pkg", [
+                      pkg.name for pkg in StripePackage.all()])
 
-    # TODO: Fix `forbidden` error in stripe views
     def test_update_package(self):
+        self.assertNotIn("updated pkg", [
+            pkg.name for pkg in StripePackage.all()])
+        updated_name = 'updated pkg'
         res = self.c.put(f'/stripepackage/update/{self.stripe_pkg.ref.id()}/',
-                          json={
-                              'stripe_id': '123',
-                              'name': 'stripe_pkg',
-                              'price': 10.10,
-                              'description': 'a test package'
-                          },
-                          headers={
-                              "Authorization": self.token,
-                              "Content-Type": "application/json"
-                          })
+                         json={
+                             'stripe_id': '123',
+                             'name': updated_name,
+                             'price': 10.10,
+                             'description': 'a test package'
+                         },
+                         headers={
+                             "Authorization": self.token,
+                             "Content-Type": "application/json"
+                         })
 
-        print(res.json)
+        self.assertTrue(res.json['success'])
+        self.assertEqual(
+            res.json['data']['data']['name'],
+            updated_name)
 
-    # TODO: Fix `forbidden` error in stripe views
     def test_delete_package(self):
         res = self.c.delete(f'/stripepackage/delete/{self.stripe_pkg.ref.id()}/',
-                          headers={
-                              "Authorization": self.token,
-                              "Content-Type": "application/json"
-                          })
+                            headers={
+                                "Authorization": self.token,
+                                "Content-Type": "application/json"
+                            })
 
-        print(res.json)
+        self.assertTrue(res.json['success'])
+        self.assertNotIn(
+            self.stripe_pkg.ref.id(),
+            [pkg.ref.id() for pkg in StripePackage.all()]
+        )

--- a/pfunk/tests/test_web_stripe.py
+++ b/pfunk/tests/test_web_stripe.py
@@ -25,7 +25,7 @@ class TestWebStripeCrud(APITestCase):
         self.stripe_pkg = StripePackage.create(group=self.group,
                                                stripe_id='100', price='10', description='unit testing...', name='unit test package')
         self.stripe_cus = StripeCustomer.create(
-            user=self.user, stripe_id='100', description="information")
+            user=self.user, stripe_id='100')
 
         self.token, self.exp = User.api_login("test", "abc123")
         self.app = self.project.wsgi_app
@@ -105,14 +105,13 @@ class TestWebStripeCrud(APITestCase):
         )
 
     def test_create_customer(self):
-        new_description = 'created description'
-        self.assertNotIn(new_description, [
-            cus.description for cus in StripeCustomer.all()])
+        stripe_id = '201'
+        self.assertNotIn(stripe_id, [
+            cus.stripe_id for cus in StripeCustomer.all()])
         res = self.c.post(f'/stripecustomer/create/',
                           json={
                               "user": self.user.ref.id(),
-                              "stripe_id": 201,
-                              "description": new_description
+                              "stripe_id": stripe_id
                           },
                           headers={
                               "Authorization": self.token,
@@ -120,8 +119,8 @@ class TestWebStripeCrud(APITestCase):
                           })
 
         self.assertTrue(res.json['success'])
-        self.assertIn(new_description, [
-                      cus.description for cus in StripeCustomer.all()])
+        self.assertIn(stripe_id, [
+                      cus.stripe_id for cus in StripeCustomer.all()])
 
     def test_list_customers(self):
         res = self.c.get('/stripecustomer/list/', headers={
@@ -131,8 +130,8 @@ class TestWebStripeCrud(APITestCase):
 
         self.assertTrue(res.json['success'])
         self.assertEqual(
-            res.json['data']['data'][0]['data']['description'],
-            'information')
+            res.json['data']['data'][0]['data']['stripe_id'],
+            '100')
 
     def test_get_customer(self):
         res = self.c.get(f'/stripecustomer/detail/{self.stripe_cus.ref.id()}/', headers={
@@ -142,16 +141,16 @@ class TestWebStripeCrud(APITestCase):
 
         self.assertTrue(res.json['success'])
         self.assertEqual(
-            res.json['data']['data']['description'],
-            'information')
+            res.json['data']['data']['stripe_id'],
+            '100')
 
     def test_update_customer(self):
-        updated_description = 'an updated description'
-        self.assertNotIn(updated_description, [
-            cus.description for cus in StripeCustomer.all()])
+        updated_stripe_id = '101'
+        self.assertNotIn(updated_stripe_id, [
+            cus.stripe_id for cus in StripeCustomer.all()])
         res = self.c.put(f'/stripecustomer/update/{self.stripe_cus.ref.id()}/',
                          json={
-                             "description": updated_description
+                             "stripe_id": updated_stripe_id
                          },
                          headers={
                              "Authorization": self.token,
@@ -160,11 +159,10 @@ class TestWebStripeCrud(APITestCase):
 
         self.assertTrue(res.json['success'])
         self.assertEqual(
-            res.json['data']['data']['description'],
-            updated_description)
+            res.json['data']['data']['stripe_id'],
+            updated_stripe_id)
 
     def test_delete_customer(self):
-        updated_description = 'an updated description'
         res = self.c.delete(f'/stripecustomer/delete/{self.stripe_cus.ref.id()}/',
                             headers={
                                 "Authorization": self.token,

--- a/pfunk/tests/test_web_stripe.py
+++ b/pfunk/tests/test_web_stripe.py
@@ -1,3 +1,6 @@
+import json
+from lib2to3.pytree import Base
+import tempfile
 from werkzeug.test import Client
 from types import SimpleNamespace
 from unittest import mock
@@ -9,11 +12,12 @@ from pfunk.testcase import APITestCase
 from pfunk.contrib.ecommerce.views import BaseWebhookView
 from pfunk.web.request import HTTPRequest
 
-class TestWebStripe(APITestCase):
+
+class TestWebStripeCrud(APITestCase):
     collections = [User, Group, StripePackage, StripeCustomer]
 
     def setUp(self) -> None:
-        super(TestWebStripe, self).setUp()
+        super(TestWebStripeCrud, self).setUp()
         self.group = Group.create(name='Power Users', slug='power-users')
         self.user = User.create(username='test', email='tlasso@example.org', first_name='Ted',
                                 last_name='Lasso', _credentials='abc123', account_status='ACTIVE',
@@ -175,7 +179,7 @@ class TestWebStripe(APITestCase):
 
 
 class TestStripeWebhook(APITestCase):
-    collections = [User, Group]
+    collections = [User, Group, StripeCustomer]
 
     def setUp(self) -> None:
         super(TestStripeWebhook, self).setUp()
@@ -186,7 +190,7 @@ class TestStripeWebhook(APITestCase):
         self.token, self.exp = User.api_login("test", "abc123")
         self.app = self.project.wsgi_app
         self.view = BaseWebhookView()
-        stripe_req_body = {
+        self.stripe_req_body = {
             "id": "evt_1CiPtv2eZvKYlo2CcUZsDcO6",
             "object": "event",
             "api_version": "2018-05-21",
@@ -202,15 +206,17 @@ class TestStripeWebhook(APITestCase):
             },
             "type": "source.chargeable"
         }
+        headers = {'HTTP_STRIPE_SIGNATURE': 'sig_112233'}
         event = {
-            'body': stripe_req_body,
+            'body': self.stripe_req_body,
             'requestContext': {
                 'web': {
                     'method': 'post',
                     'path': '/webhook',
                     'source_ip': '192.168.1.30'
                 }
-            }
+            },
+            'headers': headers
         }
         self.view.request = HTTPRequest(event=event)
         self.c = Client(self.app)
@@ -227,13 +233,58 @@ class TestStripeWebhook(APITestCase):
 
     @mock.patch('boto3.client')
     def test_send_html_email(self, mocked):
-        pass
+        # Requires to have `TEMPLATE_ROOT_DIR=/tmp` in your .env file
+        with tempfile.NamedTemporaryFile(prefix='/tmp/', suffix='.html') as tmp:
+            res = self.view.send_html_email(
+                subject='Test Subject',
+                from_email='unittesting@email.com',
+                to_email_list=['recipient@email.com'],
+                template_name=(tmp.name.split("/")[-1])
+            )
+            self.assertTrue(True)  # if there are no exceptions, then it passed
 
-    def test_check_signing_secret(self):
-        pass
+    @mock.patch('stripe.Webhook')
+    def test_check_signing_secret(self, mocked):
+        res = self.view.check_signing_secret()
+        self.assertTrue(True)  # if there are no exceptions, then it passed
 
     def test_get_transfer_data(self):
-        pass
+        self.view.event_json = self.view.request.body
+        res = self.view.get_transfer_data()
+        self.assertTrue(True)
 
-    def test_receive_post_req(self):
-        pass
+    @mock.patch('stripe.Webhook')
+    def test_receive_post_req(self, mocked):
+        with self.assertRaises(NotImplementedError):
+            self.view.event = SimpleNamespace(**self.view.request.body)
+            res = self.c.post('/stripecustomer/webhook/',
+                              json=self.stripe_req_body,
+                              headers={
+                                  'HTTP_STRIPE_SIGNATURE': 'sig_1113'
+                              })
+
+
+class TestStripeCheckoutView(APITestCase):
+    collections = [User, Group, StripePackage]
+
+    def setUp(self) -> None:
+        super(TestStripeCheckoutView, self).setUp()
+        self.group = Group.create(name='Power Users', slug='power-users')
+        self.user = User.create(username='test', email='tlasso@example.org', first_name='Ted',
+                                last_name='Lasso', _credentials='abc123', account_status='ACTIVE',
+                                groups=[self.group])
+        self.token, self.exp = User.api_login("test", "abc123")
+        self.stripe_pkg = StripePackage.create(group=self.group,
+                                               stripe_id='100', price='10', description='unit testing...', name='unit test package')
+        self.app = self.project.wsgi_app
+        self.c = Client(self.app)
+
+    @mock.patch('stripe.checkout', spec=True)
+    def test_checkout_success_view(self, mocked):
+        session_id = 'session_123'
+        res = self.c.get(f'/stripepackage/checkout-success/{session_id}/', headers={
+            'Authorization': self.token,
+            'Content-Type': 'application/json'
+        })
+        self.assertTrue(True)
+        self.assertDictEqual({'success': False, 'data': 'Not Found'}, res.json)


### PR DESCRIPTION
# Changes
- Refactored Stripe views to work better with PFunk View environment
- Refactored Stripe collections
    - Added `CheckoutSuccessView` to `StripePackage` collection
    - Added `BaseWebhookView` to `StripeCustomer` collection
    - To be able to do CRUD operations
- Added unit tests
    - Collection `StripePackage` and `StripeCustomer` CRUD operations
    - Webhook methods unit tests
    - `CheckoutSuccessView` unit tests

# Files changed/added
- `pfunk/contrib/ecommerce/collections.py`
- `pfunk/contrib/ecommerce/views.py`

# Notes
When unit testing, be sure to have `TEMPLATE_ROOT_DIR=/tmp` in your `.env` file. This is to ensure mocked file will be found.